### PR TITLE
Adicionando mapeamento biderecional Cozinha OneToMany Restaurante

### DIFF
--- a/src/main/java/com/laps/lapsfood/domain/model/Cozinha.java
+++ b/src/main/java/com/laps/lapsfood/domain/model/Cozinha.java
@@ -1,11 +1,16 @@
 package com.laps.lapsfood.domain.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
@@ -26,6 +31,10 @@ public class Cozinha {
 	@JsonProperty("descricao")
 	@Column(nullable = false)
 	private String nome;
+	
+	@JsonIgnore
+	@OneToMany(mappedBy = "cozinha")
+	private List<Restaurante> restaurantes = new ArrayList<>();
 
 
 }


### PR DESCRIPTION
**REALIZADO**
Foi estabelecido um mapeamento bidirecional entre as entidades Cozinha e Restaurante. A anotação @OneToMany foi adicionada à classe Cozinha para indicar que um restaurante pode pertencer a uma única cozinha, enquanto um restaurante pode estar associado a várias cozinhas.

**CONCEITOS ENVOLVIDOS**
No banco de dados, a tabela Restaurante possuí uma coliuna de identificação para Cozinha (cozinha_id). Ao adicionar a notação @OneToMany, estabelece-se associação da lista de Restaurantes e a Cozinha sem a necessidade de uma tabela intermediária.

É necessário a presença da anotação @JsonIgnore para evietar serialização em loop. Sem essa anotação, durante a serialização de Cozinha os Restaurantes serializados também são serializados, e vice-versa, criando uma referência circular.

A presença da referência bidirecional é útil quando há a necessidade de obter os Restaurantes associados há cozinha, sendo possível obter facilmente pela própria classe. Entretanto há desvantagens, para tal consulta, o SDJ faz N consultas para N elementos na Lista de Restaurantes, o que pode ser custoso em alguns casos, assim uma consulta específica poderia ser uma alternativa. 

**CONCLUSÃO**
Aplicar uma referência bidirecional tem vantagens como de praticidade na consulta tendo a Lista restaurantes disponível no próprio objeto pelo SDJ mas pode ser custoso, é necessário avaliar a necessidade de tal implementação.